### PR TITLE
Solve our polymorphic typealias problem

### DIFF
--- a/Aquifer/IO.swift
+++ b/Aquifer/IO.swift
@@ -48,6 +48,6 @@ public func debugDescribe<UI: CustomDebugStringConvertible, DI, DO, FR>() -> Pro
 }
 
 /// Returns a `Pipe` that prints the streamable data of input values to the given output stream.
-public func writeTo<DT: Streamable, OS: OutputStreamType, FR>(inout stream: OS) -> Proxy<(), DT, (), DT, FR> {
+public func writeTo<DT: Streamable, OS: OutputStreamType, FR>(inout stream: OS) -> Pipe<DT, DT, FR>.T {
     return chain { $0.writeTo(&stream) }
 }

--- a/Aquifer/Parsing.swift
+++ b/Aquifer/Parsing.swift
@@ -13,7 +13,7 @@ import Focus
 
 /// Splits the `Producer` into two `Producer`s, where the outer `Producer` is the longest 
 /// consecutive group of elements that satisfy the given predicate.
-public func span<V, R>(p: Proxy<X, (), (), V, R>, _ predicate: V -> Bool) -> Proxy<X, (), (), V, Proxy<X, (), (), V, R>> {
+public func span<V, R>(p: Producer<V, R>.T, _ predicate: V -> Bool) -> Producer<V, Producer<V, R>.T>.T {
     switch next(p) {
     case let .Left(x): return pure(pure(x))
     case let .Right((dO, q)):
@@ -27,12 +27,12 @@ public func span<V, R>(p: Proxy<X, (), (), V, R>, _ predicate: V -> Bool) -> Pro
 
 /// Splits the `Producer` into two `Producer`s, where the outer `Producer` is the longest 
 /// consecutive group of elements that do not satisfy the given predicate.
-public func extreme<V, R>(p: Proxy<X, (), (), V, R>, _ predicate: V -> Bool) -> Proxy<X, (), (), V, Proxy<X, (), (), V, R>> {
+public func extreme<V, R>(p: Producer<V, R>.T, _ predicate: V -> Bool) -> Producer<V, Producer<V, R>.T>.T {
     return span(p, (!) • predicate)
 }
 
 /// Splits a `Producer` into two `Producer`s after a fixed number of elements
-public func splitAt<V, R>(p: Proxy<X, (), (), V, R>, _ n: Int) -> Proxy<X, (), (), V, Proxy<X, (), (), V, R>> {
+public func splitAt<V, R>(p: Producer<V, R>.T, _ n: Int) -> Producer<V, Producer<V, R>.T>.T {
     if n <= 0 {
         return pure(p)
     } else {
@@ -46,7 +46,7 @@ public func splitAt<V, R>(p: Proxy<X, (), (), V, R>, _ n: Int) -> Proxy<X, (), (
 
 /// Splits a `Producer` into two `Producer`s after the first group of elements that are equal 
 /// according to the equality predicate.
-public func groupBy<V, R>(p: Proxy<X, (), (), V, R>, _ equals: (V, V) -> Bool) -> Proxy<X, (), (), V, Proxy<X, (), (), V, R>> {
+public func groupBy<V, R>(p: Producer<V, R>.T, _ equals: (V, V) -> Bool) -> Producer<V, Producer<V, R>.T>.T {
     switch next(p) {
     case let .Left(x): return pure(pure(x))
     case let .Right((dO, q)):
@@ -55,12 +55,12 @@ public func groupBy<V, R>(p: Proxy<X, (), (), V, R>, _ equals: (V, V) -> Bool) -
 }
 
 /// Splits a `Producer` into two `Producer`s after the first group of elements that are equal.
-public func group<V: Equatable, R>(p: Proxy<X, (), (), V, R>) -> Proxy<X, (), (), V, Proxy<X, (), (), V, R>> {
+public func group<V: Equatable, R>(p: Producer<V, R>.T) -> Producer<V, Producer<V, R>.T>.T {
     return groupBy(p) { v0, v1 in v0 == v1 }
 }
 
 /// Draws one element from the underlying `Producer`, returning `.None` if the Producer is empty
-public func draw<V, I>() -> IxState<Proxy<X, (), (), V, I>, Proxy<X, (), (), V, I>, V?> {
+public func draw<V, I>() -> IxState<Producer<V, I>.T, Producer<V, I>.T, V?> {
     return get() >>- { p in
         switch next(p) {
         case let .Left(x): return { _ in nil } <^> put(pure(x))
@@ -72,38 +72,38 @@ public func draw<V, I>() -> IxState<Proxy<X, (), (), V, I>, Proxy<X, (), (), V, 
 
 /// Skips one element of the underlying `Producer`.  The final result of the returned pipe is `true`
 /// if the operation was successful or `false` if the pipe was empty.
-public func skip<V, I>() -> IxState<Proxy<X, (), (), V, I>, Proxy<X, (), (), V, I>, Bool> {
+public func skip<V, I>() -> IxState<Producer<V, I>.T, Producer<V, I>.T, Bool> {
     return { if let _ = $0 { return true } else { return false } } <^> draw()
 }
 
 /// Draw all elements from the underlying `Producer`.
-public func drawAll<V, I>() -> IxState<Proxy<X, (), (), V, I>, Proxy<X, (), (), V, I>, List<V>> {
+public func drawAll<V, I>() -> IxState<Producer<V, I>.T, Producer<V, I>.T, List<V>> {
     return drawAllInner { v in v }
 }
 
 /// Drops all elements from the underlying `Producer`.
-public func skipAll<V, I>() -> IxState<Proxy<X, (), (), V, I>, Proxy<X, (), (), V, I>, ()> {
+public func skipAll<V, I>() -> IxState<Producer<V, I>.T, Producer<V, I>.T, ()> {
     return draw() >>- { if let _ = $0 { return skipAll() } else { return pure(()) } }
 }
 
 /// Push back an element onto the underlying `Producer`.
-public func unDraw<V, I>(x: V) -> IxState<Proxy<X, (), (), V, I>, Proxy<X, (), (), V, I>, ()> {
+public func unDraw<V, I>(x: V) -> IxState<Producer<V, I>.T, Producer<V, I>.T, ()> {
     return modify { p in yield(x) >>- { _ in p } }
 }
 
 /// Checks the first element of the pipe, but uses `unDraw` to push the element back so that it is 
 /// available for the next `draw` command.
-public func peek<V, I>() -> IxState<Proxy<X, (), (), V, I>, Proxy<X, (), (), V, I>, V?> {
+public func peek<V, I>() -> IxState<Producer<V, I>.T, Producer<V, I>.T, V?> {
     return draw() >>- { k in if let v = k { return { _ in k } <^> unDraw(v) } else { return pure(k) } }
 }
 
 /// Returns whether the underlying `Producer` is empty
-public func isEndOfInput<V, I>() -> IxState<Proxy<X, (), (), V, I>, Proxy<X, (), (), V, I>, Bool> {
+public func isEndOfInput<V, I>() -> IxState<Producer<V, I>.T, Producer<V, I>.T, Bool> {
     return { if let _ = $0 { return true } else { return false } } <^> peek()
 }
 
 /// Fold all input values.
-public func foldAll<A, V, I, R>(stepWith step: (A, V) -> A, initializeWith initial: A, extractWith extractor: A -> R) -> IxState<Proxy<X, (), (), V, I>, Proxy<X, (), (), V, I>, R> {
+public func foldAll<A, V, I, R>(stepWith step: (A, V) -> A, initializeWith initial: A, extractWith extractor: A -> R) -> IxState<Producer<V, I>.T, Producer<V, I>.T, R> {
     return draw() >>- {
         if let v = $0 {
             return foldAll(stepWith: step, initializeWith: step(initial, v), extractWith: extractor)
@@ -114,17 +114,17 @@ public func foldAll<A, V, I, R>(stepWith step: (A, V) -> A, initializeWith initi
 }
 
 // this seems to required higher-kinded types to implement, even though none appear in its signature
-/*public func toParser<V, I, R>(p: Proxy<(), V?, (), X, R>) -> IxState<Proxy<X, (), (), V, I>, Proxy<X, (), (), V, I>, R> {
+/*public func toParser<V, I, R>(p: Proxy<(), V?, (), X, R>) -> IxState<Producer<V, I>.T, Producer<V, I>.T, R> {
 }*/
 
 /// Convert a never-ending Consumer to a Parser
-public func toParser<V, I>(endless p: Proxy<(), V, (), X, X>) -> IxState<Proxy<X, (), (), V, I>, Proxy<X, (), (), V, I>, ()> {
+public func toParser<V, I>(endless p: Consumer<V, X>.T) -> IxState<Producer<V, I>.T, Producer<V, I>.T, ()> {
     return IxState { q in ((), pure(runEffect(q >-> ({ closed($0) } <^> p)))) }
 }
 
 // MARK: - Implementation Details Follow
 
-private func drawAllInner<V, I>(diffAs: List<V> -> List<V>) -> IxState<Proxy<X, (), (), V, I>, Proxy<X, (), (), V, I>, List<V>> {
+private func drawAllInner<V, I>(diffAs: List<V> -> List<V>) -> IxState<Producer<V, I>.T, Producer<V, I>.T, List<V>> {
     return draw() >>- {
         if let v = $0 {
             return drawAllInner(diffAs • curry(List.cons)(v))

--- a/Aquifer/Proxy.swift
+++ b/Aquifer/Proxy.swift
@@ -82,6 +82,30 @@ public struct Proxy<UO, UI, DI, DO, FR> {
     }
 }
 
+struct Effect<Result> {
+    typealias T = Proxy<X, (), (), X, Result>
+}
+
+struct Producer<B, Result> {
+    typealias T = Proxy<X, (), (), B, Result>
+}
+
+struct Pipe<A, B, Result> {
+    typealias T = Proxy<(), A, (), B, Result>
+}
+
+struct Consumer<A, Result> {
+    typealias T = Proxy<(), A, (), X, Result>
+}
+
+struct Client<RequestT, RespondT, Result> {
+    typealias T = Proxy<RequestT, RespondT, (), X, Result>
+}
+
+struct Server<ReceiveT, RespondT, Result> {
+    typealias T = Proxy<X, (), ReceiveT, RespondT, Result>
+}
+
 /// Forces a pipe to evaluate its contents lazily.
 public func delay<UO, UI, DI, DO, FR>(@autoclosure(escaping) p: () -> Proxy<UO, UI, DI, DO, FR>) -> Proxy<UO, UI, DI, DO, FR> {
     return Proxy(p().repr)

--- a/Aquifer/Proxy.swift
+++ b/Aquifer/Proxy.swift
@@ -83,27 +83,27 @@ public struct Proxy<UO, UI, DI, DO, FR> {
 }
 
 public enum Effect<Result> {
-    typealias T = Proxy<X, (), (), X, Result>
+    public typealias T = Proxy<X, (), (), X, Result>
 }
 
 public enum Producer<B, Result> {
-    typealias T = Proxy<X, (), (), B, Result>
+    public typealias T = Proxy<X, (), (), B, Result>
 }
 
 public enum Pipe<A, B, Result> {
-    typealias T = Proxy<(), A, (), B, Result>
+    public typealias T = Proxy<(), A, (), B, Result>
 }
 
 public enum Consumer<A, Result> {
-    typealias T = Proxy<(), A, (), X, Result>
+    public typealias T = Proxy<(), A, (), X, Result>
 }
 
 public enum Client<RequestT, RespondT, Result> {
-    typealias T = Proxy<RequestT, RespondT, (), X, Result>
+    public typealias T = Proxy<RequestT, RespondT, (), X, Result>
 }
 
 public enum Server<ReceiveT, RespondT, Result> {
-    typealias T = Proxy<X, (), ReceiveT, RespondT, Result>
+    public typealias T = Proxy<X, (), ReceiveT, RespondT, Result>
 }
 
 /// Forces a pipe to evaluate its contents lazily.
@@ -166,7 +166,7 @@ public func flatten<UO, UI, DI, DO, FR>(p: Proxy<UO, UI, DI, DO, Proxy<UO, UI, D
 }
 
 /// Runs a self-contained "Effect" and yields a final value. 
-public func runEffect<FR>(p: Proxy<X, (), (), X, FR>) -> FR {
+public func runEffect<FR>(p: Effect<FR>.T) -> FR {
     switch p.repr {
     case let .Request(uO, _): return closed(uO())
     case let .Respond(dO, _): return closed(dO())

--- a/Aquifer/Proxy.swift
+++ b/Aquifer/Proxy.swift
@@ -12,6 +12,33 @@ import Swiftz
 
 /// A bidirectional channel for information.
 ///
+/// A `Proxy` is so named because it can represent many different kinds of information flows.  There
+/// are 6 overarching specific types that a `Proxy` can represent, each with separate semantics.
+///
+/// An effectful computation.
+///
+///     typealias Effect<Result> = Proxy<X, (), (), X, Result>
+///
+/// A computation that yields values of type `B`.
+///
+///     typealias Producer<B, Result> = Proxy<X, (), (), B, Result>
+///
+/// A computation that can await values of type `A` and yield values of type `B`.
+///
+///     typealias Pipe<A, B, Result> = Proxy<(), A, (), B, Result>
+///
+/// A computation that can await values of type `A`.
+///
+///     typealias Consumer<A, Result> = Proxy<(), A, (), X, Result>
+///
+/// Sends requests of type `RequestT` and recieves responses of type `RespondT`.
+///
+///     typealias Client<RequestT, RespondT, Result> = Proxy<RequestT, RespondT, (), X, Result>
+///
+/// Receives values of type `ReceiveT` and responds with values of type `RespondT`.
+///
+///     typealias Server<ReceiveT, RespondT, Result> = Proxy<X, (), ReceiveT, RespondT, Result>
+///
 /// The type parameters are as follows:
 ///
 /// UO - upstream   output
@@ -48,9 +75,6 @@ public struct Proxy<UO, UI, DI, DO, FR> {
         return Proxy<DO, DI, UI, UO, FR>(self.repr.reflect())
     }
 }
-
-/// A `Proxy` is so named because it can represent many different kinds of information flows.  There
-/// are 6 overarching specific types that a `Proxy` can represent, each with separate semantics.
 
 /// An effectful computation.
 ///

--- a/Aquifer/Proxy.swift
+++ b/Aquifer/Proxy.swift
@@ -82,27 +82,27 @@ public struct Proxy<UO, UI, DI, DO, FR> {
     }
 }
 
-struct Effect<Result> {
+public enum Effect<Result> {
     typealias T = Proxy<X, (), (), X, Result>
 }
 
-struct Producer<B, Result> {
+public enum Producer<B, Result> {
     typealias T = Proxy<X, (), (), B, Result>
 }
 
-struct Pipe<A, B, Result> {
+public enum Pipe<A, B, Result> {
     typealias T = Proxy<(), A, (), B, Result>
 }
 
-struct Consumer<A, Result> {
+public enum Consumer<A, Result> {
     typealias T = Proxy<(), A, (), X, Result>
 }
 
-struct Client<RequestT, RespondT, Result> {
+public enum Client<RequestT, RespondT, Result> {
     typealias T = Proxy<RequestT, RespondT, (), X, Result>
 }
 
-struct Server<ReceiveT, RespondT, Result> {
+public enum Server<ReceiveT, RespondT, Result> {
     typealias T = Proxy<X, (), ReceiveT, RespondT, Result>
 }
 

--- a/Aquifer/Proxy.swift
+++ b/Aquifer/Proxy.swift
@@ -12,39 +12,6 @@ import Swiftz
 
 /// A bidirectional channel for information.
 ///
-/// A `Proxy` is so named because it can represent many different kinds of information flows.  There
-/// are 6 overarching specific types that a `Proxy` can represent, each with separate semantics.
-///
-///     /// An effectful computation.
-///     ///
-///     /// `Effect`s neither await nor yield.
-///     typealias Effect<Result> = Proxy<X, (), (), X, Result>
-///
-///     /// A computation that yields values of type `B`.
-///     ///
-///     /// `Producer`s can only yield.
-///     typealias Producer<B, Result> = Proxy<X, (), (), B, Result>
-///
-///     /// A computation that can await values of type `A` and yield values of type `B`.
-///     ///
-///     /// `Pipe`s can both await and yield.
-///     typealias Pipe<A, B, Result> = Proxy<(), A, (), B, Result>
-///
-///     /// A computation that can await values of type `A`.
-///     ///
-///     /// `Consumer`s can only await.
-///     typealias Consumer<A, Result> = Proxy<(), A, (), X, Result>
-///
-///     /// Sends requests of type `RequestT` and recieves responses of type `RespondT`.
-///     ///
-///     /// `Client`s only request and never respond.
-///     typealias Client<RequestT, RespondT, Result> = Proxy<RequestT, RespondT, (), X, Result>
-///
-///     /// Receives values of type `ReceiveT` and responds with values of type `RespondT`.
-///     ///
-///     /// `Server`s only respond and never request.
-///     typealias Server<ReceiveT, RespondT, Result> = Proxy<X, (), ReceiveT, RespondT, Result>
-///
 /// The type parameters are as follows:
 ///
 /// UO - upstream   output
@@ -82,26 +49,47 @@ public struct Proxy<UO, UI, DI, DO, FR> {
     }
 }
 
+/// A `Proxy` is so named because it can represent many different kinds of information flows.  There
+/// are 6 overarching specific types that a `Proxy` can represent, each with separate semantics.
+
+/// An effectful computation.
+///
+/// `Effect`s neither await nor yield.
 public enum Effect<Result> {
     public typealias T = Proxy<X, (), (), X, Result>
 }
 
+/// A computation that yields values of type `B`.
+///
+/// `Producer`s can only yield.
 public enum Producer<B, Result> {
     public typealias T = Proxy<X, (), (), B, Result>
 }
 
+/// A computation that can await values of type `A` and yield values of type `B`.
+///
+/// `Pipe`s can both await and yield.
 public enum Pipe<A, B, Result> {
     public typealias T = Proxy<(), A, (), B, Result>
 }
 
+/// A computation that can await values of type `A`.
+///
+/// `Consumer`s can only await.
 public enum Consumer<A, Result> {
     public typealias T = Proxy<(), A, (), X, Result>
 }
 
+/// Sends requests of type `RequestT` and recieves responses of type `RespondT`.
+///
+/// `Client`s only request and never respond.
 public enum Client<RequestT, RespondT, Result> {
     public typealias T = Proxy<RequestT, RespondT, (), X, Result>
 }
 
+/// Receives values of type `ReceiveT` and responds with values of type `RespondT`.
+///
+/// `Server`s only respond and never request.
 public enum Server<ReceiveT, RespondT, Result> {
     public typealias T = Proxy<X, (), ReceiveT, RespondT, Result>
 }

--- a/Aquifer/Simple.swift
+++ b/Aquifer/Simple.swift
@@ -15,7 +15,7 @@ import Swiftz
 /// If the subsequent state of the `Pipe` is a single value or termination, the result is `.Left`
 /// containing the value.  Otherwise the result is `.Right` containing the value and the next state
 /// of the pipe.
-public func next<DO, FR>(p: Proxy<X, (), (), DO, FR>) -> Either<FR, (DO, Proxy<X, (), (), DO, FR>)> {
+public func next<DO, FR>(p: Producer<DO, FR>.T) -> Either<FR, (DO, Producer<DO, FR>.T)> {
     switch p.repr {
     case let .Request(uO, _): return closed(uO())
     case let .Respond(dO, fDI): return .Right((dO(), Proxy(fDI(()))))
@@ -52,7 +52,7 @@ public func await<UI, DI, DO>() -> Proxy<(), UI, DI, DO, UI> {
 /// The identity `Pipe`.
 ///
 /// Like the Unix `cat` program, pushes any given input as output without modification.
-public func cat<DT, FR>() -> Proxy<(), DT, (), DT, FR> {
+public func cat<DT, FR>() -> Pipe<DT, DT, FR>.T {
     return pull(())
 }
 

--- a/AquiferTests/TestDefs.swift
+++ b/AquiferTests/TestDefs.swift
@@ -138,7 +138,7 @@ extension AClient : Arbitrary {
 	}
 }
 
-func aClient(client : AClient) -> (Int -> Proxy<Int, Int, (), X, Int> /* Client<Int, Int, Int> */) {
+func aClient(client : AClient) -> (Int -> Client<Int, Int, Int>.T) {
 	let p = client.unAClient.map({ (x : ClientStep) -> (Int -> Proxy<Int, Int, (), X, Int>) in
 		switch x {
 		case .ClientRequest:
@@ -170,7 +170,7 @@ extension AServer : Arbitrary {
 	}
 }
 
-func aServer(server : AServer) -> (Int -> Proxy<X, (), Int, Int, Int> /* Server<Int, Int, Int> */) {
+func aServer(server : AServer) -> (Int -> Server<Int, Int, Int>.T) {
 	return server.unAServer.map({ (x : ServerStep) -> (Int -> Proxy<X, (), Int, Int, Int>) in
 		switch x {
 		case .ServerRespond:


### PR DESCRIPTION
While I was porting parts of the test suite, I remembered an old trick for recovering template aliases with `typealias`es in structs.  This pull request is just a sketch for now so I don't forget it.
