### PR TITLE
Fix #13

### DIFF
--- a/Aquifer.xcodeproj/project.pbxproj
+++ b/Aquifer.xcodeproj/project.pbxproj
@@ -192,7 +192,7 @@
 
 /* Begin PBXFileReference section */
 		110A96CD1B7D9447005667D4 /* Swiftz.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Swiftz.xcodeproj; path = Carthage/Checkouts/swiftz/Swiftz.xcodeproj; sourceTree = "<group>"; };
-		11200E741A7723BD0032A136 /* Simple.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Simple.swift; sourceTree = "<group>"; usesTabs = 0; };
+		11200E741A7723BD0032A136 /* Simple.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Simple.swift; sourceTree = "<group>"; usesTabs = 1; };
 		11200E821A784D230032A136 /* Parsing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Parsing.swift; sourceTree = "<group>"; usesTabs = 0; };
 		11200E861A7953120032A136 /* IO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IO.swift; sourceTree = "<group>"; usesTabs = 0; };
 		11200E891A7958580032A136 /* NSFileHandleExt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSFileHandleExt.h; sourceTree = "<group>"; };

--- a/Aquifer/Auxiliary.swift
+++ b/Aquifer/Auxiliary.swift
@@ -22,7 +22,7 @@ public func arr<A, B, R>(f: A -> B) -> Pipe<A, B, R>.T {
 /// pipe has operated on them.  Values appearing along the upstream input in a `.Right` will appear
 /// downstream in a `.Right` unchanged.
 public func left<A, B, C, R>(p: Pipe<A, B, R>.T) -> Pipe<Either<A, C>, Either<B, C>, R>.T {
-    return leftInner() >~ for_(p) { v in yield(Either.Left(v)) }
+    return leftInner() >~~ for_(p) { v in yield(Either.Left(v)) }
 }
 
 /// Returns a pipe that acts like `right` from Control.Arrow.
@@ -31,7 +31,7 @@ public func left<A, B, C, R>(p: Pipe<A, B, R>.T) -> Pipe<Either<A, C>, Either<B,
 /// the pipe has operated on them.  Values appearing along the upstream input in a `.Left` will
 /// appear downstream in a `.Left` unchanged.
 public func right<A, B, C, R>(p: Pipe<A, B, R>.T) -> Pipe<Either<C, A>, Either<C, B>, R>.T {
-    return rightInner() >~ for_(p) { v in yield(Either.Right(v)) }
+    return rightInner() >~~ for_(p) { v in yield(Either.Right(v)) }
 }
 
 infix operator +++ {

--- a/Aquifer/Basic.swift
+++ b/Aquifer/Basic.swift
@@ -187,12 +187,12 @@ public func scan<A, UI, DO, FR>(stepWith step: (A, UI) -> A, initializeWith init
 
 /// Returns a pipe that always produces the given value.
 public func repeat_<UO, UI, DO, FR>(v: () -> DO) -> Proxy<UO, UI, (), DO, FR> {
-    return once(v) >~ cat()
+    return once(v) >~~ cat()
 }
 
 /// Returns a pipe that produces the given value a set amount of times.
 public func replicate<UO, UI, DO>(v: () -> DO, n: Int) -> Proxy<UO, UI, (), DO, ()> {
-    return once(v) >~ take(n)
+    return once(v) >~~ take(n)
 }
 
 // MARK: Input Subsets

--- a/Aquifer/Info.plist
+++ b/Aquifer/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.2.1</string>
+	<string>0.2.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Aquifer/Simple.swift
+++ b/Aquifer/Simple.swift
@@ -68,6 +68,8 @@ precedence 130
 }
 
 /// Into | Composes two loops to yield one large loop.
+///
+/// The corresponding operator in `pipes` is `~>`.
 public func ~~> <IS, UO, UI, DI, DO, NI, NO, FR>(f: IS -> Proxy<UO, UI, DI, DO, FR>, g: DO -> Proxy<UO, UI, NI, NO, DI>) -> IS -> Proxy<UO, UI, NI, NO, FR> {
     return f |>| g
 }
@@ -78,6 +80,8 @@ precedence 130
 }
 
 /// Into | Composes two loops to yield one large loop.
+///
+/// The corresponding operator in `pipes` is `<~`.
 public func <~~ <IS, UO, UI, DI, DO, NI, NO, FR>(f: DO -> Proxy<UO, UI, NI, NO, DI>, g: IS -> Proxy<UO, UI, DI, DO, FR>) -> IS -> Proxy<UO, UI, NI, NO, FR> {
     return g |>| f
 }
@@ -88,6 +92,8 @@ precedence 140
 }
 
 /// Replaces each value `yielded` in the left pipe with the right pipe.
+///
+/// The corresponding operator in `pipes` is `~<`.
 public func ~~< <UO, UI, DI, DO, FR, NR>(p: Proxy<(), FR, DI, DO, NR>, q: Proxy<UO, UI, DI, DO, FR>) -> Proxy<UO, UI, DI, DO, NR> {
     return q >~~ p
 }
@@ -98,6 +104,8 @@ precedence 140
 }
 
 /// Replaces each value `yielded` in the right pipe with the left pipe.
+///
+/// The corresponding operator in `pipes` is `>~`.
 public func >~~ <UO, UI, DI, DO, FR, NR>(p: Proxy<UO, UI, DI, DO, FR>, q: Proxy<(), FR, DI, DO, NR>) -> Proxy<UO, UI, DI, DO, NR> {
     return { _ in p } >>| q
 }

--- a/Aquifer/Simple.swift
+++ b/Aquifer/Simple.swift
@@ -62,45 +62,43 @@ public func for_<UO, UI, DI, DO, NI, NO, FR>(p: Proxy<UO, UI, DI, DO, FR>, _ f: 
     return p |>> f
 }
 
-// FIXME: The Swift STL thinks it's OK to leave all operators, even private ones, at global public
-// scope.
-// infix operator ~> {
-// associativity right
-// precedence 130
-// }
+infix operator ~~> {
+associativity right
+precedence 130
+}
 
 /// Into | Composes two loops to yield one large loop.
-public func ~> <IS, UO, UI, DI, DO, NI, NO, FR>(f: IS -> Proxy<UO, UI, DI, DO, FR>, g: DO -> Proxy<UO, UI, NI, NO, DI>) -> IS -> Proxy<UO, UI, NI, NO, FR> {
+public func ~~> <IS, UO, UI, DI, DO, NI, NO, FR>(f: IS -> Proxy<UO, UI, DI, DO, FR>, g: DO -> Proxy<UO, UI, NI, NO, DI>) -> IS -> Proxy<UO, UI, NI, NO, FR> {
     return f |>| g
 }
 
-infix operator <~ {
+infix operator <~~ {
 associativity left
 precedence 130
 }
 
 /// Into | Composes two loops to yield one large loop.
-public func <~ <IS, UO, UI, DI, DO, NI, NO, FR>(f: DO -> Proxy<UO, UI, NI, NO, DI>, g: IS -> Proxy<UO, UI, DI, DO, FR>) -> IS -> Proxy<UO, UI, NI, NO, FR> {
+public func <~~ <IS, UO, UI, DI, DO, NI, NO, FR>(f: DO -> Proxy<UO, UI, NI, NO, DI>, g: IS -> Proxy<UO, UI, DI, DO, FR>) -> IS -> Proxy<UO, UI, NI, NO, FR> {
     return g |>| f
 }
 
-infix operator ~< {
+infix operator ~~< {
 associativity left
 precedence 140
 }
 
 /// Replaces each value `yielded` in the left pipe with the right pipe.
-public func ~< <UO, UI, DI, DO, FR, NR>(p: Proxy<(), FR, DI, DO, NR>, q: Proxy<UO, UI, DI, DO, FR>) -> Proxy<UO, UI, DI, DO, NR> {
-    return q >~ p
+public func ~~< <UO, UI, DI, DO, FR, NR>(p: Proxy<(), FR, DI, DO, NR>, q: Proxy<UO, UI, DI, DO, FR>) -> Proxy<UO, UI, DI, DO, NR> {
+    return q >~~ p
 }
 
-infix operator >~ {
+infix operator >~~ {
 associativity right
 precedence 140
 }
 
 /// Replaces each value `yielded` in the right pipe with the left pipe.
-public func >~ <UO, UI, DI, DO, FR, NR>(p: Proxy<UO, UI, DI, DO, FR>, q: Proxy<(), FR, DI, DO, NR>) -> Proxy<UO, UI, DI, DO, NR> {
+public func >~~ <UO, UI, DI, DO, FR, NR>(p: Proxy<UO, UI, DI, DO, FR>, q: Proxy<(), FR, DI, DO, NR>) -> Proxy<UO, UI, DI, DO, NR> {
     return { _ in p } >>| q
 }
 

--- a/Aquifer/Simple.swift
+++ b/Aquifer/Simple.swift
@@ -63,8 +63,8 @@ public func for_<UO, UI, DI, DO, NI, NO, FR>(p: Proxy<UO, UI, DI, DO, FR>, _ f: 
 }
 
 infix operator ~~> {
-associativity right
-precedence 130
+    associativity right
+    precedence 130
 }
 
 /// Into | Composes two loops to yield one large loop.
@@ -75,8 +75,8 @@ public func ~~> <IS, UO, UI, DI, DO, NI, NO, FR>(f: IS -> Proxy<UO, UI, DI, DO, 
 }
 
 infix operator <~~ {
-associativity left
-precedence 130
+    associativity left
+    precedence 130
 }
 
 /// Into | Composes two loops to yield one large loop.
@@ -87,8 +87,8 @@ public func <~~ <IS, UO, UI, DI, DO, NI, NO, FR>(f: DO -> Proxy<UO, UI, NI, NO, 
 }
 
 infix operator ~~< {
-associativity left
-precedence 140
+    associativity left
+    precedence 140
 }
 
 /// Replaces each value `yielded` in the left pipe with the right pipe.
@@ -99,8 +99,8 @@ public func ~~< <UO, UI, DI, DO, FR, NR>(p: Proxy<(), FR, DI, DO, NR>, q: Proxy<
 }
 
 infix operator >~~ {
-associativity right
-precedence 140
+    associativity right
+    precedence 140
 }
 
 /// Replaces each value `yielded` in the right pipe with the left pipe.
@@ -111,8 +111,8 @@ public func >~~ <UO, UI, DI, DO, FR, NR>(p: Proxy<UO, UI, DI, DO, FR>, q: Proxy<
 }
 
 infix operator >-> {
-associativity left
-precedence 160
+    associativity left
+    precedence 160
 }
 
 /// Compose | Composes two pipes by attaching the output of the first to the input of the second.
@@ -123,8 +123,8 @@ public func >-> <UO, UI, DI, DO, DDI, DDO, FR>(p: Proxy<UO, UI, DI, DO, FR>, q: 
 }
 
 infix operator <-< {
-associativity right
-precedence 160
+    associativity right
+    precedence 160
 }
 
 /// Compose Backwards | Composes two pipes by attaching the output of the second to the input of the

--- a/Tutorial.playground/contents.xcplayground
+++ b/Tutorial.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='osx' requires-full-environment='true' display-mode='raw' timelineScrubberEnabled='true'>
+<playground version='5.0' target-platform='osx' requires-full-environment='true' display-mode='rendered' timelineScrubberEnabled='true'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>

--- a/Tutorial.playground/contents.xcplayground
+++ b/Tutorial.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='osx' requires-full-environment='true' display-mode='rendered' timelineScrubberEnabled='true'>
+<playground version='5.0' target-platform='osx' requires-full-environment='true' display-mode='raw' timelineScrubberEnabled='true'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>


### PR DESCRIPTION
Renamed:
- `~>` to `~~>`
- `>~` to `>~~`
- `<~` to `<~~`
- `~<` to `~~<`

I also took the liberty of removing the “FIXME” and updating the tutorial appropriately.
